### PR TITLE
feat(bot): DI factory and dev/prod adapter wiring (closes #11)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
 import 'dotenv/config'
 
-import { createBot } from './modules/bot/index.js'
+import { createBot, createDevBot } from './modules/bot/index.js'
 
-const bot = createBot(process.env.BOT_TOKEN ?? '')
+const useMocks = (process.env.USE_MOCKS ?? 'false').toLowerCase() === 'true'
+const bot = (useMocks ? createDevBot : createBot)(process.env.BOT_TOKEN ?? '')
 bot.launch()
 
 process.once('SIGINT', () => bot.stop('SIGINT'))

--- a/src/modules/bot/bot.ts
+++ b/src/modules/bot/bot.ts
@@ -1,25 +1,35 @@
 import { Telegraf } from 'telegraf'
-
-import {
-  freegame,
-  longweek,
-  onCallbackQuery,
-  trivia,
-  whosplaying,
-} from '../events/index.js'
+import type { ControllerDependencies } from '../infra/controllers/events.controllers.js'
+import { createEvents } from '../events/index.js'
 import { maintenance } from '../infra/utils.js'
+import { createServiceAdapters, createDevServiceAdapters } from '../infra/adapters/service.adapters.js'
 
-export default (token: string) => {
+export type CreateBot = (token: string, deps: ControllerDependencies) => Telegraf
+
+export const createBotWithDeps: CreateBot = (token, deps) => {
   const bot = new Telegraf(token)
+  const events = createEvents(deps)
 
-  bot.command('freegames', freegame)
-  bot.command('semanalonga', longweek)
-  bot.command('trivia', trivia)
+  bot.command('freegames', events.freegame)
+  bot.command('semanalonga', events.longweek)
+  bot.command('trivia', events.trivia)
 
   bot.command('nyvi', maintenance)
-  bot.command('whosplaying', whosplaying)
+  bot.command('whosplaying', events.whosplaying)
 
-  bot.on('callback_query', onCallbackQuery)
+  bot.on('callback_query', events.onCallbackQuery)
 
   return bot
 }
+
+export const createBot = (token: string) => {
+  const deps = createServiceAdapters()
+  return createBotWithDeps(token, deps)
+}
+
+export const createDevBot = (token: string) => {
+  const deps = createDevServiceAdapters()
+  return createBotWithDeps(token, deps)
+}
+
+export default createBot

--- a/src/modules/bot/index.ts
+++ b/src/modules/bot/index.ts
@@ -1,1 +1,2 @@
 export { default as createBot } from './bot.js'
+export { createBot as createProdBot, createDevBot, createBotWithDeps } from './bot.js'

--- a/src/modules/events/events.ts
+++ b/src/modules/events/events.ts
@@ -1,11 +1,13 @@
 import { createControllers } from '../infra/controllers/events.controllers.js'
-import { createServiceAdapters } from '../infra/adapters/service.adapters.js'
+import type { ControllerDependencies } from '../infra/controllers/events.controllers.js'
 
-const serviceAdapters = createServiceAdapters()
-const controllers = createControllers(serviceAdapters)
-
-export const longweek = controllers.longweek
-export const freegame = controllers.freegame
-export const whosplaying = controllers.whosplaying
-export const trivia = controllers.trivia
-export const onCallbackQuery = controllers.onCallbackQuery
+export const createEvents = (dependencies: ControllerDependencies) => {
+	const controllers = createControllers(dependencies)
+	return {
+		longweek: controllers.longweek,
+		freegame: controllers.freegame,
+		whosplaying: controllers.whosplaying,
+		trivia: controllers.trivia,
+		onCallbackQuery: controllers.onCallbackQuery,
+	}
+}

--- a/src/modules/infra/adapters/service.adapters.ts
+++ b/src/modules/infra/adapters/service.adapters.ts
@@ -8,6 +8,7 @@ import type {
   TriviaService, 
   WhosplayingService 
 } from '../controllers/events.controllers.js'
+import { MockAiService } from '../mocks/ai.mock.js'
 
 export class AiServiceAdapter implements AiService {
   async generate(input: string, systemPrompt: string, history?: any[]): Promise<any> {
@@ -39,5 +40,14 @@ export const createServiceAdapters = () => {
     freeGamesService: new FreeGamesServiceAdapter(),
     triviaService: new TriviaServiceAdapter(),
     whosplayingService: new WhosplayingServiceAdapter()
+  }
+}
+
+export const createDevServiceAdapters = () => {
+  return {
+    aiService: new MockAiService(),
+    freeGamesService: new FreeGamesServiceAdapter(),
+    triviaService: new TriviaServiceAdapter(),
+    whosplayingService: new WhosplayingServiceAdapter(),
   }
 }

--- a/src/modules/infra/function.ts
+++ b/src/modules/infra/function.ts
@@ -1,7 +1,7 @@
 import http from 'serverless-http'
 import type { Callback, Context, Handler } from 'aws-lambda'
 
-import { createBot } from '../bot/index.js'
+import { createProdBot as createBot } from '../bot/index.js'
 
 let proxy: Handler
 


### PR DESCRIPTION
This PR implements issue #11 by introducing a DI-based factory for the bot and cleanly wiring adapters for production and development.

Summary
- events: add `createEvents(dependencies)` to expose handlers from injected services
- bot: add `createBotWithDeps(token, deps)`, `createBot(token)` (prod adapters), and `createDevBot(token)` (mock AI + real services)
- adapters: add `createDevServiceAdapters()` using `MockAiService`
- index: allow `USE_MOCKS=true` to boot dev bot locally, default remains prod
- lambda: import `createProdBot` to ensure production behavior in serverless

Why
- Enables dependency injection for handlers, improving testability and flexibility
- Keeps runtime behavior unchanged for production paths
- Prepares for future expansion (e.g., alternate AI providers)

Notes
- Preserves `.js` extensions in local imports to remain compatible with Node ESM + SWC build
- Tests pass (Vitest), and build succeeds locally

Closes #11.