### PR TITLE
feat(ai): provider-agnostic AiProvider port, adapter wiring, controller migration, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ npm run test:cov   # with coverage
 
 Controllers are tested with mock services (see `src/modules/infra/mocks/ai.mock.ts`).
 
+### AI provider port
+
+- Controllers depend on a provider-agnostic `AiProvider` returning `{ text }`.
+- Adapters map neutral `ChatMessage[]` and simple `CommonGenerationConfig` to the underlying SDK and extract text internally.
+- History helpers like `whosplayingHistory` are provider-agnostic.
+
 ## License
 
 [MIT](LICENSE)

--- a/docs/ai-port.md
+++ b/docs/ai-port.md
@@ -1,0 +1,73 @@
+# AI Provider Port (`AiProvider`)
+
+This document describes the AI provider port and how to use it inside controllers/adapters.
+
+## Interface
+
+```ts
+export type Role = 'system' | 'user' | 'assistant'
+
+export type ChatMessage = {
+  role: Role
+  content: string
+}
+
+export type CommonGenerationConfig = {
+  temperature?: number
+  topP?: number
+  topK?: number
+  maxTokens?: number
+  stopSequences?: string[]
+}
+
+export type GenerateOptions = {
+  system?: string
+  history?: ChatMessage[]
+  config?: CommonGenerationConfig
+}
+
+export type AiResponse = {
+  text: string
+}
+
+export interface AiProvider {
+  generate(input: string, options?: GenerateOptions): Promise<AiResponse>
+}
+```
+
+- `input`: user/content string to send to the model.
+- `options.system`: system prompt (when the provider supports it).
+- `options.history`: prior conversation history.
+- `options.config`: provider-agnostic generation config; providers may ignore unsupported fields.
+
+## Usage in controllers
+
+Inject something implementing `AiProvider` and call `generate(...)`. Receive plain text via `AiResponse.text`.
+
+```ts
+const controller = (deps: { ai: AiProvider }) => async (ctx: Context) => {
+  const result = await deps.ai.generate(JSON.stringify(payload), {
+    system: systemPrompt,
+    history,
+  })
+  await ctx.reply(text(result))
+}
+```
+
+## Adapters
+
+Implementations can wrap concrete SDKs (e.g., Google Generative AI):
+
+```ts
+class VertexAiProvider implements AiProvider {
+  async generate(input: string, { system, history, config }: GenerateOptions = {}) {
+    // Map neutral types -> provider types, call SDK, then map back to AiResponse
+    const result = await generate(input, system ?? '', /* map history to vendor */ undefined)
+    return { text: text(result) }
+  }
+}
+```
+
+## Notes
+- Keep `.js` extensions in imports inside `.ts` sources for Node ESM.
+- Adapters should use `text(result)` internally; controllers receive `AiResponse.text` only.

--- a/docs/module-boundaries.md
+++ b/docs/module-boundaries.md
@@ -42,16 +42,17 @@ Modules
 - Public API:
   - Controllers factory: `createControllers(deps)`
   - Adapters factories: `createServiceAdapters()`, `createDevServiceAdapters()`
-  - Types: `AiService`, `FreeGamesService`, `TriviaService`, `WhosplayingService`, `ControllerDependencies`
+    - Types: `AiProvider`, `FreeGamesService`, `TriviaService`, `WhosplayingService`, `ControllerDependencies`
   - Utils: `maintenance(ctx)`
 
 4) modules/ai
 - Purpose: LLM generation and helpers.
 - Files: `src/modules/ai/ai/engine.ts`, `src/modules/ai/ai/output.ts`, `src/modules/ai/ai/history.ts`, `src/modules/ai/ai/system.prompt.ts`, `src/modules/ai/index.ts`
 - Public API:
-  - `generate(input: string, system: string, history?: Content[]): Promise<GenerateContentResult>`
-  - `text(result: GenerateContentResult): string`
-  - `whosplayingHistory: Content[]`
+  - `AiProvider` (port interface), `ChatMessage`, `CommonGenerationConfig`, `AiResponse`
+  - `generate(input: string, system: string, history?: Content[]): Promise<GenerateContentResult>` (adapter-internal)
+  - `text(result: GenerateContentResult): string` (adapter-internal)
+  - `whosplayingHistory: ChatMessage[]`
   - `triviaExpert: string`, `whosplayingExpert: string`
 
 5) modules/freegames

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -33,13 +33,15 @@ Tests the refactored event controllers that now use dependency injection:
 
 ### Mock Services
 
-#### MockAiService (`src/modules/infra/mocks/ai.mock.ts`)
+#### MockAiProvider (`src/modules/infra/mocks/ai.mock.ts`)
 
-Provides predictable AI responses for testing:
+Provider-agnostic AI mock returning plain text via `AiResponse`:
 
 ```typescript
-const mockAi = new MockAiService()
-mockAi.setMockResponse('input', { response: { text: () => 'output' } })
+const mockAi = new MockAiProvider()
+mockAi.setMockResponse('input', 'output')
+// controller deps
+const controller = createWhosplayingController({ aiProvider: mockAi, whosplayingService })
 ```
 
 ## Architecture Benefits
@@ -49,7 +51,7 @@ The refactored controllers now:
 1. **Accept injected dependencies** instead of importing services directly
 2. **Are easily testable** with mock services
 3. **Maintain identical behavior** to the original implementation
-4. **Support different service implementations** (real vs mock)
+4. **Support different provider implementations** (real vs mock) behind `AiProvider`
 
 ## Adding New Tests
 

--- a/src/modules/ai/ai/history.ts
+++ b/src/modules/ai/ai/history.ts
@@ -1,28 +1,16 @@
-import type { Content } from '@google/generative-ai'
+import type { ChatMessage } from './provider.interface.js'
 
-export const whosplayingHistory: Content[] = [
+export const whosplayingHistory: ChatMessage[] = [
+  { role: 'user', content: '[]' },
+  { role: 'assistant', content: 'Ninguém tá jogando no momento. 😢' },
   {
     role: 'user',
-    parts: [{ text: '[]' }],
+    content:
+      '[{"displayName":"Harald","activities":[{"name":"League of Legends","details":"Howling Abyss (ARAM)","state":"In Lobby","party":{"size":3}}]}]',
   },
   {
-    role: 'model',
-    parts: [{ text: 'Ninguém tá jogando no momento. 😢' }],
-  },
-  {
-    role: 'user',
-    parts: [
-      {
-        text: '[{"displayName":"Harald","activities":[{"name":"League of Legends","details":"Howling Abyss (ARAM)","state":"In Lobby","party":{"size":3}}]}]',
-      },
-    ],
-  },
-  {
-    role: 'model',
-    parts: [
-      {
-        text: 'Harald está na fila para jogar League of Legends no modo ARAM com mais duas pessoas. 😜',
-      },
-    ],
+    role: 'assistant',
+    content:
+      'Harald está na fila para jogar League of Legends no modo ARAM com mais duas pessoas. 😜',
   },
 ]

--- a/src/modules/ai/ai/provider.interface.ts
+++ b/src/modules/ai/ai/provider.interface.ts
@@ -1,0 +1,28 @@
+export type Role = 'system' | 'user' | 'assistant'
+
+export type ChatMessage = {
+  role: Role
+  content: string
+}
+
+export type CommonGenerationConfig = {
+  temperature?: number
+  topP?: number
+  topK?: number
+  maxTokens?: number
+  stopSequences?: string[]
+}
+
+export type GenerateOptions = {
+  system?: string
+  history?: ChatMessage[]
+  config?: CommonGenerationConfig
+}
+
+export type AiResponse = {
+  text: string
+}
+
+export interface AiProvider {
+  generate(input: string, options?: GenerateOptions): Promise<AiResponse>
+}

--- a/src/modules/ai/index.ts
+++ b/src/modules/ai/index.ts
@@ -2,3 +2,11 @@ export { generate } from './ai/engine.js'
 export { text } from './ai/output.js'
 export { whosplayingHistory } from './ai/history.js'
 export { triviaExpert, whosplayingExpert } from './ai/system.prompt.js'
+export type {
+	AiProvider,
+	GenerateOptions,
+	ChatMessage,
+	Role,
+	CommonGenerationConfig,
+	AiResponse,
+} from './ai/provider.interface.js'

--- a/src/modules/infra/adapters/service.adapters.ts
+++ b/src/modules/infra/adapters/service.adapters.ts
@@ -1,4 +1,4 @@
-import { generate } from '../../ai/index.js'
+import { generate, text } from '../../ai/index.js'
 import { getFreeGames } from '../../freegames/index.js'
 import { getQuestions } from '../../trivia/index.js'
 import { getOnlineMembers } from '../../whosplaying/index.js'
@@ -8,12 +8,32 @@ import type {
   TriviaService, 
   WhosplayingService 
 } from '../controllers/events.controllers.js'
-import { MockAiService } from '../mocks/ai.mock.js'
+import { MockAiService, MockAiProvider } from '../mocks/ai.mock.js'
+import type { AiProvider, GenerateOptions, ChatMessage, AiResponse } from '../../ai/index.js'
+import type { Content } from '@google/generative-ai'
 
 export class AiServiceAdapter implements AiService {
   async generate(input: string, systemPrompt: string, history?: any[]): Promise<any> {
     return generate(input, systemPrompt, history)
   }
+}
+
+export class AiProviderAdapter implements AiProvider {
+  async generate(input: string, options?: GenerateOptions): Promise<AiResponse> {
+    const system = options?.system ?? ''
+    const history = options?.history ? mapHistory(options.history) : undefined
+    const result = await generate(input, system, history)
+    return { text: text(result) }
+  }
+}
+
+const mapHistory = (history: ChatMessage[]): Content[] => {
+  return history
+    .filter((m) => m.role === 'user' || m.role === 'assistant')
+    .map((m) => ({
+      role: m.role === 'assistant' ? 'model' : 'user',
+      parts: [{ text: m.content }],
+    })) as Content[]
 }
 
 export class FreeGamesServiceAdapter implements FreeGamesService {
@@ -37,6 +57,7 @@ export class WhosplayingServiceAdapter implements WhosplayingService {
 export const createServiceAdapters = () => {
   return {
     aiService: new AiServiceAdapter(),
+    aiProvider: new AiProviderAdapter(),
     freeGamesService: new FreeGamesServiceAdapter(),
     triviaService: new TriviaServiceAdapter(),
     whosplayingService: new WhosplayingServiceAdapter()
@@ -46,6 +67,7 @@ export const createServiceAdapters = () => {
 export const createDevServiceAdapters = () => {
   return {
     aiService: new MockAiService(),
+    aiProvider: new MockAiProvider(),
     freeGamesService: new FreeGamesServiceAdapter(),
     triviaService: new TriviaServiceAdapter(),
     whosplayingService: new WhosplayingServiceAdapter(),

--- a/src/modules/infra/mocks/ai.mock.ts
+++ b/src/modules/infra/mocks/ai.mock.ts
@@ -1,4 +1,5 @@
 import type { AiService } from '../controllers/events.controllers.js'
+import type { AiProvider, AiResponse, GenerateOptions } from '../../ai/index.js'
 
 export class MockAiService implements AiService {
   private mockResponses: Map<string, any> = new Map()
@@ -17,6 +18,25 @@ export class MockAiService implements AiService {
         text: () => `Mock AI response for: ${input.substring(0, 50)}...`
       }
     }
+  }
+
+  clearMockResponses(): void {
+    this.mockResponses.clear()
+  }
+}
+
+export class MockAiProvider implements AiProvider {
+  private mockResponses: Map<string, string> = new Map()
+
+  setMockResponse(input: string, response: string): void {
+    this.mockResponses.set(input, response)
+  }
+
+  async generate(input: string, _options?: GenerateOptions): Promise<AiResponse> {
+    if (this.mockResponses.has(input)) {
+      return { text: this.mockResponses.get(input)! }
+    }
+    return { text: `Mock AI response for: ${input.substring(0, 50)}...` }
   }
 
   clearMockResponses(): void {

--- a/tests/controllers.test.ts
+++ b/tests/controllers.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { createWhosplayingController, createLongweekController } from '../src/modules/infra/controllers/events.controllers.js'
-import { MockAiService } from '../src/modules/infra/mocks/ai.mock.js'
+import { MockAiProvider } from '../src/modules/infra/mocks/ai.mock.js'
 import type { WhosplayingService } from '../src/modules/infra/controllers/events.controllers.js'
 
 const createMockContext = () => ({
@@ -17,15 +17,15 @@ const createMockWhosplayingService = (): WhosplayingService => ({
 
 describe('Event Controllers', () => {
   describe('WhosplayingController', () => {
-    let mockAiService: MockAiService
+  let mockAiProvider: MockAiProvider
     let mockWhosplayingService: WhosplayingService
     let controller: ReturnType<typeof createWhosplayingController>
 
     beforeEach(() => {
-      mockAiService = new MockAiService()
+      mockAiProvider = new MockAiProvider()
       mockWhosplayingService = createMockWhosplayingService()
       controller = createWhosplayingController({
-        aiService: mockAiService,
+        aiProvider: mockAiProvider,
         whosplayingService: mockWhosplayingService
       })
     })
@@ -35,12 +35,10 @@ describe('Event Controllers', () => {
       const mockMembers = [
         { displayName: 'User1', username: 'user1', activities: [{ name: 'Playing Game' }] }
       ]
-      const mockAiResponse = {
-        response: { text: () => 'User1 is playing Game!' }
-      }
+      const mockAiResponseText = 'User1 is playing Game!'
 
       vi.mocked(mockWhosplayingService.getOnlineMembers).mockResolvedValue(mockMembers)
-      mockAiService.setMockResponse(JSON.stringify(mockMembers), mockAiResponse)
+  mockAiProvider.setMockResponse(JSON.stringify(mockMembers), mockAiResponseText)
 
       await controller(mockContext as any)
 


### PR DESCRIPTION
This PR implements issue #12.

Highlights
- Introduces provider-agnostic AI port:
  - `AiProvider` interface with neutral types: `ChatMessage`, `CommonGenerationConfig`, `AiResponse`.
  - Barrel exports for types in `src/modules/ai/index.ts`.
- Adapter and wiring:
  - `AiProviderAdapter` maps neutral types to Google GenAI via existing engine, returns `{ text }`.
  - Dev wiring uses `MockAiProvider`.
  - Factories now expose `aiProvider` alongside legacy `aiService` (to ease transition if any stragglers exist).
- Controller migration:
  - Controllers depend on `AiProvider` and consume `AiResponse.text`.
  - Replaced vendor-typed `whosplayingHistory` with neutral `ChatMessage[]`.
- Tests:
  - Updated `tests/controllers.test.ts` to use `MockAiProvider`.
- Docs:
  - New `docs/ai-port.md`.
  - Updated `README.md`, `docs/module-boundaries.md`, `docs/testing.md`, and `.github/copilot-instructions.md`.

Why
- Fully decouple business logic from a specific AI SDK, reduce blast radius for future provider changes, and simplify mocking/testing at the port boundary.

Notes
- Next step (optional): Remove `AiService` altogether once no usage remains.
- Streaming or tool use can be added later via optional methods without breaking the basic contract.

Validation
- `npm run build` – PASS
- `npm test` – PASS (3/3)
