### PR TITLE
feat(mock-ai): deterministic MockAiProvider fallback hash + docs (closes #14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Controllers are tested with mock services (see `src/modules/infra/mocks/ai.mock.
 Enable the mock provider with `USE_MOCKS=true`. The `MockAiProvider`:
 
 - Allows explicit seeding via `setMockResponse(input, output)`
-- Produces a stable fallback hash (`mock:<hex16>`) based on `(input, system, history, config)` when not seeded
+- Produces a stable fallback hash (`mock:<hex16>`) based on `(input, system, history, config)` using stable key ordering when not seeded
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,22 @@ Controllers are tested with mock services (see `src/modules/infra/mocks/ai.mock.
 - Adapters map neutral `ChatMessage[]` and simple `CommonGenerationConfig` to the underlying SDK and extract text internally.
 - History helpers like `whosplayingHistory` are provider-agnostic.
 
+### Deterministic mock AI
+
+Enable the mock provider with `USE_MOCKS=true`. The `MockAiProvider`:
+
+- Allows explicit seeding via `setMockResponse(input, output)`
+- Produces a stable fallback hash (`mock:<hex16>`) based on `(input, system, history, config)` when not seeded
+
+Example:
+
+```ts
+const mock = new MockAiProvider()
+const a = await mock.generate('hello', { system: 's' })
+const b = await mock.generate('hello', { system: 's' })
+// a.text === b.text (deterministic)
+```
+
 ## License
 
 [MIT](LICENSE)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -44,6 +44,18 @@ mockAi.setMockResponse('input', 'output')
 const controller = createWhosplayingController({ aiProvider: mockAi, whosplayingService })
 ```
 
+Deterministic fallback:
+
+If you do not register a specific mock response via `setMockResponse`, the mock generates a stable hashed output derived from the tuple `(input, system, history, config)`:
+
+```
+// Unseeded call
+const { text } = await mockAi.generate('some input', { system: 'sys' })
+// text -> e.g. mock:3fae9c1b7d2a4f10 (hex hash prefix)
+```
+
+This guarantees the same inputs always yield the same mock output, removing randomness from tests while keeping responses compact.
+
 ## Architecture Benefits
 
 The refactored controllers now:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -54,7 +54,7 @@ const { text } = await mockAi.generate('some input', { system: 'sys' })
 // text -> e.g. mock:3fae9c1b7d2a4f10 (hex hash prefix)
 ```
 
-This guarantees the same inputs always yield the same mock output, removing randomness from tests while keeping responses compact.
+This guarantees the same inputs always yield the same mock output (stable object key ordering via custom serializer), removing randomness from tests while keeping responses compact.
 
 ## Architecture Benefits
 

--- a/src/modules/infra/mocks/ai.mock.ts
+++ b/src/modules/infra/mocks/ai.mock.ts
@@ -44,12 +44,15 @@ export class MockAiProvider implements AiProvider {
       return { text: this.mockResponses.get(input)! }
     }
     const system = options?.system || ''
+    const isRoleContentMsg = (m: any): m is { role: string; content: string } =>
+      m && typeof m.role === 'string' && typeof m.content === 'string'
     const historyKey = options?.history
-      ?.filter(m => m.role !== 'system')
+      ?.filter(isRoleContentMsg)
+      .filter(m => m.role !== 'system')
       .map(m => `${m.role}:${m.content}`)
       .join('|') || ''
     const configKey = options?.config ? JSON.stringify(options.config) : ''
-    const composite = [input, system, historyKey, configKey].join('§')
+    const composite = JSON.stringify([input, system, historyKey, configKey])
     const hash = crypto.createHash('sha256').update(composite).digest('hex').slice(0, 16)
     return { text: `mock:${hash}` }
   }

--- a/src/modules/infra/mocks/ai.mock.ts
+++ b/src/modules/infra/mocks/ai.mock.ts
@@ -15,15 +15,19 @@ export class MockAiService implements AiServiceLegacy {
     this.mockResponses.set(input, response)
   }
 
-  async generate(input: string, systemPrompt: string, history?: any[]): Promise<any> {
+  async generate(
+    input: string,
+    systemPrompt: string,
+    history?: any[],
+  ): Promise<any> {
     if (this.mockResponses.has(input)) {
       return this.mockResponses.get(input)
     }
 
     return {
       response: {
-        text: () => `Mock AI response for: ${input.substring(0, 50)}...`
-      }
+        text: () => `Mock AI response for: ${input.substring(0, 50)}...`,
+      },
     }
   }
 
@@ -36,31 +40,54 @@ export class MockAiProvider implements AiProvider {
   private mockResponses: Map<string, string> = new Map()
 
   private stableSerialize(value: any): string {
-    if (value === null || typeof value !== 'object') return JSON.stringify(value)
-    if (Array.isArray(value)) return '[' + value.map(v => this.stableSerialize(v)).join(',') + ']'
+    if (value === null || typeof value !== 'object')
+      return JSON.stringify(value)
+    if (Array.isArray(value))
+      return '[' + value.map((v) => this.stableSerialize(v)).join(',') + ']'
     const keys = Object.keys(value).sort()
-    return '{' + keys.map(k => JSON.stringify(k) + ':' + this.stableSerialize(value[k])).join(',') + '}'
+    return (
+      '{' +
+      keys
+        .map((k) => JSON.stringify(k) + ':' + this.stableSerialize(value[k]))
+        .join(',') +
+      '}'
+    )
   }
 
   setMockResponse(input: string, response: string): void {
     this.mockResponses.set(input, response)
   }
 
-  async generate(input: string, options?: GenerateOptions): Promise<AiResponse> {
+  async generate(
+    input: string,
+    options?: GenerateOptions,
+  ): Promise<AiResponse> {
     if (this.mockResponses.has(input)) {
       return { text: this.mockResponses.get(input)! }
     }
     const system = options?.system || ''
     const isRoleContentMsg = (m: any): m is { role: string; content: string } =>
       m && typeof m.role === 'string' && typeof m.content === 'string'
-    const historyKey = options?.history
-      ?.filter(isRoleContentMsg)
-      .filter(m => m.role !== 'system')
-      .map(m => `${m.role}:${m.content}`)
-      .join('|') || ''
-    const configKey = options?.config ? this.stableSerialize(options.config) : ''
-  const composite = this.stableSerialize({ input, system, history: historyKey, config: configKey })
-    const hash = crypto.createHash('sha256').update(composite).digest('hex').slice(0, 16)
+    const historyKey =
+      options?.history
+        ?.filter(isRoleContentMsg)
+        .filter((m) => m.role !== 'system')
+        .map((m) => `${m.role}:${m.content}`)
+        .join('|') || ''
+    const configKey = options?.config
+      ? this.stableSerialize(options.config)
+      : ''
+    const composite = this.stableSerialize({
+      input,
+      system,
+      history: historyKey,
+      config: configKey,
+    })
+    const hash = crypto
+      .createHash('sha256')
+      .update(composite)
+      .digest('hex')
+      .slice(0, 16)
     return { text: `mock:${hash}` }
   }
 

--- a/src/modules/infra/mocks/ai.mock.ts
+++ b/src/modules/infra/mocks/ai.mock.ts
@@ -60,15 +60,17 @@ export class MockAiProvider implements AiProvider {
 
   private buildHistoryKey(history?: any[]): string {
     if (!history || history.length === 0) return ''
-    const isRoleContentMsg = (m: any): m is { role: string; content: string } =>
-      m && typeof m.role === 'string' && typeof m.content === 'string'
     return (
       history
-        .filter(isRoleContentMsg)
+        .filter(this.isRoleContentMsg)
         .filter((m) => m.role !== 'system')
         .map((m) => `${m.role}:${m.content}`)
         .join('|') || ''
     )
+  }
+
+  private isRoleContentMsg(m: any): m is { role: string; content: string } {
+    return m && typeof m.role === 'string' && typeof m.content === 'string'
   }
 
   async generate(

--- a/src/modules/infra/mocks/ai.mock.ts
+++ b/src/modules/infra/mocks/ai.mock.ts
@@ -59,7 +59,7 @@ export class MockAiProvider implements AiProvider {
       .map(m => `${m.role}:${m.content}`)
       .join('|') || ''
     const configKey = options?.config ? this.stableSerialize(options.config) : ''
-    const composite = this.stableSerialize([input, system, historyKey, configKey])
+  const composite = this.stableSerialize({ input, system, history: historyKey, config: configKey })
     const hash = crypto.createHash('sha256').update(composite).digest('hex').slice(0, 16)
     return { text: `mock:${hash}` }
   }

--- a/src/modules/infra/mocks/ai.mock.ts
+++ b/src/modules/infra/mocks/ai.mock.ts
@@ -58,6 +58,19 @@ export class MockAiProvider implements AiProvider {
     this.mockResponses.set(input, response)
   }
 
+  private buildHistoryKey(history?: any[]): string {
+    if (!history || history.length === 0) return ''
+    const isRoleContentMsg = (m: any): m is { role: string; content: string } =>
+      m && typeof m.role === 'string' && typeof m.content === 'string'
+    return (
+      history
+        .filter(isRoleContentMsg)
+        .filter((m) => m.role !== 'system')
+        .map((m) => `${m.role}:${m.content}`)
+        .join('|') || ''
+    )
+  }
+
   async generate(
     input: string,
     options?: GenerateOptions,
@@ -66,14 +79,7 @@ export class MockAiProvider implements AiProvider {
       return { text: this.mockResponses.get(input)! }
     }
     const system = options?.system || ''
-    const isRoleContentMsg = (m: any): m is { role: string; content: string } =>
-      m && typeof m.role === 'string' && typeof m.content === 'string'
-    const historyKey =
-      options?.history
-        ?.filter(isRoleContentMsg)
-        .filter((m) => m.role !== 'system')
-        .map((m) => `${m.role}:${m.content}`)
-        .join('|') || ''
+    const historyKey = this.buildHistoryKey(options?.history)
     const configKey = options?.config
       ? this.stableSerialize(options.config)
       : ''


### PR DESCRIPTION
Implements deterministic behavior for MockAiProvider and updates documentation.

Changes
- MockAiProvider now returns stable `mock:<hash16>` fallback derived from (input, system, history, config)
- Added hashing via sha256 (first 16 hex chars) for brevity
- Added deterministic documentation to README and testing guide
- Introduced local legacy AiService interface in mock file pending #58

Docs
- README: new section "Deterministic mock AI"
- docs/testing.md: deterministic fallback explanation & example

Acceptance criteria
- Stable output without seeding: YES
- Docs updated with usage & overriding: YES

Follow-ups
- #15 can add explicit tests asserting deterministic hash stability
- #58 will remove legacy AiService + mock

Closes #14