### PR TITLE
test(ai): expand controller and adapter coverage; add deterministic mock tests (closes #15)

### DIFF
--- a/tests/mock.ai.test.ts
+++ b/tests/mock.ai.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { MockAiProvider } from '../src/modules/infra/mocks/ai.mock.js'
+import type { GenerateOptions, ChatMessage } from '../src/modules/ai/index.js'
+
+describe('MockAiProvider', () => {
+  it('returns deterministic fallback for same inputs', async () => {
+    const mock = new MockAiProvider()
+    const history: ChatMessage[] = [
+      { role: 'user', content: 'hello' },
+      { role: 'assistant', content: 'world' },
+      { role: 'system', content: 'ignored' }
+    ]
+    const opts: GenerateOptions = {
+      system: 'sys',
+      history,
+      config: { temperature: 0.2, maxTokens: 16 }
+    }
+    const a = await mock.generate('input', opts)
+    const b = await mock.generate('input', opts)
+    expect(a.text).toEqual(b.text)
+    expect(a.text.startsWith('mock:')).toBe(true)
+  })
+
+  it('changes fallback when config/history changes', async () => {
+    const mock = new MockAiProvider()
+    const a = await mock.generate('input', {
+      system: 'sys',
+      history: [ { role: 'user', content: 'hello' } ] as ChatMessage[],
+      config: { temperature: 0.2 }
+    })
+    const b = await mock.generate('input', {
+      system: 'sys',
+      history: [ { role: 'user', content: 'hello' } ] as ChatMessage[],
+      config: { temperature: 0.3 }
+    })
+    expect(a.text).not.toEqual(b.text)
+  })
+
+  it('honors setMockResponse overrides', async () => {
+    const mock = new MockAiProvider()
+    mock.setMockResponse('foo', 'bar')
+    const res = await mock.generate('foo')
+    expect(res.text).toBe('bar')
+  })
+})


### PR DESCRIPTION
This PR implements issue #15 by expanding unit tests across the AI port.

Changes
- Controllers: assert `AiProvider.generate` is called with expected `system` and `history` for whosplaying, and response is replied.
- Adapter: verify mapping of system/history to SDK (`systemInstruction`, `startChat.history`) and config mapping (`temperature`, `topP`, `topK`, `maxOutputTokens`, `stopSequences`).
- MockAiProvider: add deterministic fallback tests and `setMockResponse` override test.

Results
- All tests pass locally (Vitest): 11 tests across 3 files.

Notes
- Keeps existing adapter error/timeout tests intact, adds concrete assertions for mapping.

Closes #15.