### PR TITLE
feat(providers): define TriviaProvider and FreeGamesProvider ports, add mocks and docs (refs #38)

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,0 +1,39 @@
+# Provider Ports: Trivia and FreeGames
+
+This document introduces provider interfaces that decouple domain services from external APIs and enable easy mocking.
+
+## FreeGamesProvider
+
+- Interface: `FreeGamesProvider`
+- Method: `getPromotions(): Promise<FreeGamesPromotionsResponse>`
+- Mock: `MockFreeGamesProvider`
+
+Example
+```ts
+import { MockFreeGamesProvider } from '../src/modules/freegames/index.js'
+
+const provider = new MockFreeGamesProvider({
+  data: { Catalog: { searchStore: { elements: [], paging: { count: 0, total: 0 } } } }
+} as any)
+
+const res = await provider.getPromotions()
+```
+
+## TriviaProvider
+
+- Interface: `TriviaProvider`
+- Method: `getQuestions(params: { amount?, difficulty?, category? }): Promise<TriviaResponse>`
+- Mock: `MockTriviaProvider`
+
+Example
+```ts
+import { MockTriviaProvider } from '../src/modules/trivia/index.js'
+
+const provider = new MockTriviaProvider({ response_code: 0, results: [] })
+const res = await provider.getQuestions({ amount: 1 })
+```
+
+## Usage
+
+- These ports don’t replace existing services yet; they pave the way to inject providers under adapters (`createServiceAdapters`) and to use mocks in `createDevServiceAdapters`.
+- Future work may refactor services to depend on these providers internally.

--- a/src/modules/freegames/freegames/provider.interface.ts
+++ b/src/modules/freegames/freegames/provider.interface.ts
@@ -1,0 +1,5 @@
+import type { FreeGamesPromotionsResponse } from './freegames.interface.js'
+
+export interface FreeGamesProvider {
+  getPromotions(): Promise<FreeGamesPromotionsResponse>
+}

--- a/src/modules/freegames/freegames/provider.mock.ts
+++ b/src/modules/freegames/freegames/provider.mock.ts
@@ -1,0 +1,9 @@
+import type { FreeGamesProvider } from './provider.interface.js'
+import type { FreeGamesPromotionsResponse } from './freegames.interface.js'
+
+export class MockFreeGamesProvider implements FreeGamesProvider {
+  constructor(private data: FreeGamesPromotionsResponse) {}
+  async getPromotions(): Promise<FreeGamesPromotionsResponse> {
+    return this.data
+  }
+}

--- a/src/modules/freegames/index.ts
+++ b/src/modules/freegames/index.ts
@@ -1,3 +1,5 @@
 export * from './freegames/freegames.helper.js'
 export * from './freegames/freegames.service.js'
 export * from './freegames/freegames.interface.js'
+export * from './freegames/provider.interface.js'
+export * from './freegames/provider.mock.js'

--- a/src/modules/trivia/index.ts
+++ b/src/modules/trivia/index.ts
@@ -1,3 +1,5 @@
 export * from './trivia/trivia.helper.js'
 export * from './trivia/trivia.service.js'
 export * from './trivia/trivia.interface.js'
+export * from './trivia/provider.interface.js'
+export * from './trivia/provider.mock.js'

--- a/src/modules/trivia/trivia/provider.interface.ts
+++ b/src/modules/trivia/trivia/provider.interface.ts
@@ -1,0 +1,11 @@
+import type { CategoryId, Difficulty, TriviaResponse } from './trivia.interface.js'
+
+export type GetQuestionsParams = {
+  amount?: number
+  difficulty?: Difficulty
+  category?: CategoryId
+}
+
+export interface TriviaProvider {
+  getQuestions(params: GetQuestionsParams): Promise<TriviaResponse>
+}

--- a/src/modules/trivia/trivia/provider.mock.ts
+++ b/src/modules/trivia/trivia/provider.mock.ts
@@ -1,0 +1,9 @@
+import type { TriviaProvider, GetQuestionsParams } from './provider.interface.js'
+import type { TriviaResponse } from './trivia.interface.js'
+
+export class MockTriviaProvider implements TriviaProvider {
+  constructor(private data: TriviaResponse) {}
+  async getQuestions(_params: GetQuestionsParams): Promise<TriviaResponse> {
+    return this.data
+  }
+}

--- a/tests/mock.ai.test.ts
+++ b/tests/mock.ai.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { MockAiProvider } from '../src/modules/infra/mocks/ai.mock.js'
+import type { GenerateOptions, ChatMessage } from '../src/modules/ai/index.js'
+
+describe('MockAiProvider', () => {
+  it('returns deterministic fallback for same inputs', async () => {
+    const mock = new MockAiProvider()
+    const history: ChatMessage[] = [
+      { role: 'user', content: 'hello' },
+      { role: 'assistant', content: 'world' },
+      { role: 'system', content: 'ignored' }
+    ]
+    const opts: GenerateOptions = {
+      system: 'sys',
+      history,
+      config: { temperature: 0.2, maxTokens: 16 }
+    }
+    const a = await mock.generate('input', opts)
+    const b = await mock.generate('input', opts)
+    expect(a.text).toEqual(b.text)
+    expect(a.text.startsWith('mock:')).toBe(true)
+  })
+
+  it('changes fallback when config/history changes', async () => {
+    const mock = new MockAiProvider()
+    const a = await mock.generate('input', {
+      system: 'sys',
+      history: [ { role: 'user', content: 'hello' } ] as ChatMessage[],
+      config: { temperature: 0.2 }
+    })
+    const b = await mock.generate('input', {
+      system: 'sys',
+      history: [ { role: 'user', content: 'hello' } ] as ChatMessage[],
+      config: { temperature: 0.3 }
+    })
+    expect(a.text).not.toEqual(b.text)
+  })
+
+  it('honors setMockResponse overrides', async () => {
+    const mock = new MockAiProvider()
+    mock.setMockResponse('foo', 'bar')
+    const res = await mock.generate('foo')
+    expect(res.text).toBe('bar')
+  })
+})


### PR DESCRIPTION
Implements provider ports per #38 to decouple domains from external APIs and enable mocking.

What’s included
- Trivia: `TriviaProvider` + `GetQuestionsParams` interface and `MockTriviaProvider` implementation.
- FreeGames: `FreeGamesProvider` interface and `MockFreeGamesProvider` implementation.
- Docs: `docs/providers.md` with examples and usage notes.
- Exports: added to `freegames/index.ts` and `trivia/index.ts` barrels.

Notes
- This change doesn’t refactor existing services to use providers yet; it establishes the contracts and mocks first.
- A follow-up can adapt `createDevServiceAdapters` to optionally consume these mocks for local dev.
