### PR TITLE
feat(providers): add Trivia and FreeGames provider adapters with tests (implements #39)

### DIFF
--- a/src/modules/freegames/freegames/adapter.ts
+++ b/src/modules/freegames/freegames/adapter.ts
@@ -1,0 +1,29 @@
+import type { FreeGamesProvider } from './provider.interface.js'
+import type { FreeGame } from './freegames.interface.js'
+import { getFreeGames as fetchFreeGames } from './freegames.service.js'
+
+export class FreeGamesServiceProviderAdapter implements FreeGamesProvider {
+  constructor(private readonly maxRetries = 2, private readonly delayMs = 200) {}
+
+  async getPromotions(): Promise<any> {
+    // Expose raw promotions is not directly supported by current service; return empty shape for now
+    return { data: { Catalog: { searchStore: { elements: [], paging: { count: 0, total: 0 } } } } }
+  }
+
+  async getFreeGames(): Promise<FreeGame[]> {
+    let attempt = 0
+    while (true) {
+      attempt++
+      try {
+        return await fetchFreeGames()
+      } catch (err: any) {
+        if (attempt > this.maxRetries) throw err
+        await this.sleep(this.delayMs * 2 ** (attempt - 1))
+      }
+    }
+  }
+
+  private sleep(ms: number) {
+    return new Promise((r) => setTimeout(r, ms))
+  }
+}

--- a/src/modules/freegames/freegames/provider.interface.ts
+++ b/src/modules/freegames/freegames/provider.interface.ts
@@ -1,5 +1,6 @@
-import type { FreeGamesPromotionsResponse } from './freegames.interface.js'
+import type { FreeGamesPromotionsResponse, FreeGame } from './freegames.interface.js'
 
 export interface FreeGamesProvider {
   getPromotions(): Promise<FreeGamesPromotionsResponse>
+  getFreeGames(): Promise<FreeGame[]>
 }

--- a/src/modules/trivia/trivia/adapter.ts
+++ b/src/modules/trivia/trivia/adapter.ts
@@ -1,0 +1,27 @@
+import type { TriviaProvider, GetQuestionsParams } from './provider.interface.js'
+import { CategoryId } from './trivia.interface.js'
+import { getQuestions as fetchQuestions } from './trivia.service.js'
+
+export class TriviaServiceProviderAdapter implements TriviaProvider {
+  constructor(private readonly timeoutMs = parseInt(process.env.TRIVIA_TIMEOUT_MS || '8000')) {}
+  async getQuestions(params: GetQuestionsParams = {}): Promise<any[]> {
+    const p = fetchQuestions({
+      amount: params.amount ?? 1,
+      difficulty: params.difficulty ?? 'medium',
+      category: params.category ?? CategoryId.General,
+    })
+    return await this.callWithTimeout(p)
+  }
+
+  private async callWithTimeout<T>(p: Promise<T>): Promise<T> {
+    let handle: any
+    const t = new Promise<never>((_, rej) => {
+      handle = setTimeout(() => rej(new Error('trivia timeout')), this.timeoutMs)
+    })
+    try {
+      return (await Promise.race([p, t])) as T
+    } finally {
+      clearTimeout(handle)
+    }
+  }
+}

--- a/src/modules/trivia/trivia/provider.interface.ts
+++ b/src/modules/trivia/trivia/provider.interface.ts
@@ -1,4 +1,4 @@
-import type { CategoryId, Difficulty, TriviaResponse } from './trivia.interface.js'
+import type { CategoryId, Difficulty, Quiz } from './trivia.interface.js'
 
 export type GetQuestionsParams = {
   amount?: number
@@ -7,5 +7,5 @@ export type GetQuestionsParams = {
 }
 
 export interface TriviaProvider {
-  getQuestions(params: GetQuestionsParams): Promise<TriviaResponse>
+  getQuestions(params: GetQuestionsParams): Promise<Quiz[]>
 }

--- a/tests/providers.adapter.test.ts
+++ b/tests/providers.adapter.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// Trivia adapter tests
+vi.mock('../src/modules/trivia/trivia/trivia.service.js', () => ({
+  getQuestions: vi.fn(async () => [{ title: 'Q', options: ['A','B'], correctOptionIndex: 0 }])
+}))
+import { getQuestions as triviaGetQuestions } from '../src/modules/trivia/trivia/trivia.service.js'
+import { TriviaServiceProviderAdapter } from '../src/modules/trivia/trivia/adapter.js'
+
+// Freegames adapter tests
+vi.mock('../src/modules/freegames/freegames/freegames.service.js', () => ({
+  getFreeGames: vi.fn(async () => ([{ state: 'active', title: 'Game', slug: 'game', photo: '', start: '2020-01-01', end: '2020-01-02' }]))
+}))
+import { getFreeGames as freegamesGetFreeGames } from '../src/modules/freegames/freegames/freegames.service.js'
+import { FreeGamesServiceProviderAdapter } from '../src/modules/freegames/freegames/adapter.js'
+
+describe('Provider adapters', () => {
+  it('Trivia adapter returns quizzes and respects defaults', async () => {
+    const adapter = new TriviaServiceProviderAdapter(50)
+    const res = await adapter.getQuestions({})
+    expect(res.length).toBe(1)
+    expect(triviaGetQuestions).toHaveBeenCalledOnce()
+  })
+
+  it('FreeGames adapter returns free games with retry', async () => {
+    const adapter = new FreeGamesServiceProviderAdapter(1, 1)
+    const res = await adapter.getFreeGames()
+    expect(res.length).toBe(1)
+    expect(freegamesGetFreeGames).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
Implements concrete provider adapters per #39:

- Trivia: `TriviaServiceProviderAdapter` wraps existing `getQuestions` with timeout control.
- FreeGames: `FreeGamesServiceProviderAdapter` wraps existing `getFreeGames` with simple retry and backoff.
- Tests: Added `tests/providers.adapter.test.ts` mocking underlying services to assert behavior.

Notes
- `FreeGamesProvider.getPromotions()` is included for future expansion, current adapter returns an empty promotions shape because the existing service returns already-mapped free games.
- Follow-up could adapt services to fetch raw promotions when needed.
