### PR TITLE
refactor(ai): remove legacy AiService and MockAiService; simplify adapters wiring (implements #58)

### DIFF
--- a/src/modules/infra/adapters/service.adapters.ts
+++ b/src/modules/infra/adapters/service.adapters.ts
@@ -1,4 +1,4 @@
-import { generate, text } from '../../ai/index.js'
+import { text } from '../../ai/index.js'
 import { getFreeGames } from '../../freegames/index.js'
 import { getQuestions } from '../../trivia/index.js'
 import { getOnlineMembers } from '../../whosplaying/index.js'
@@ -7,24 +7,12 @@ import type {
   TriviaService, 
   WhosplayingService 
 } from '../controllers/events.controllers.js'
-import { MockAiService, MockAiProvider } from '../mocks/ai.mock.js'
+import { MockAiProvider } from '../mocks/ai.mock.js'
 import type { AiProvider, GenerateOptions, ChatMessage, AiResponse } from '../../ai/index.js'
 import type { Content, GenerationConfig } from '@google/generative-ai'
 import { AiError } from '../../ai/index.js'
 
-// Temporary legacy interface pending removal (#58)
-export interface AiService {
-  generate(input: string, systemPrompt: string, history?: any[]): Promise<any>
-}
 import { GoogleGenerativeAI } from '@google/generative-ai'
-
-export class AiServiceAdapter implements AiService {
-  async generate(input: string, systemPrompt: string, history?: any[]): Promise<any> {
-    return generate(input, systemPrompt, history)
-  }
-}
-
-// Backwards compatibility adapter still used by legacy AiServiceAdapter above.
 
 export class VertexAiProviderAdapter implements AiProvider {
   private readonly client: GoogleGenerativeAI
@@ -180,7 +168,6 @@ export class WhosplayingServiceAdapter implements WhosplayingService {
 
 export const createServiceAdapters = () => {
   return {
-    aiService: new AiServiceAdapter(),
     aiProvider: new VertexAiProviderAdapter(),
     freeGamesService: new FreeGamesServiceAdapter(),
     triviaService: new TriviaServiceAdapter(),
@@ -190,7 +177,6 @@ export const createServiceAdapters = () => {
 
 export const createDevServiceAdapters = () => {
   return {
-    aiService: new MockAiService(),
     aiProvider: new MockAiProvider(),
     freeGamesService: new FreeGamesServiceAdapter(),
     triviaService: new TriviaServiceAdapter(),

--- a/src/modules/infra/mocks/ai.mock.ts
+++ b/src/modules/infra/mocks/ai.mock.ts
@@ -1,41 +1,6 @@
 import type { AiProvider, AiResponse, GenerateOptions } from '../../ai/index.js'
 import crypto from 'node:crypto'
 
-// Legacy mock retained until AiService removal (#58)
-export interface AiServiceLegacy {
-  generate(input: string, systemPrompt: string, history?: any[]): Promise<any>
-  setMockResponse(input: string, response: any): void
-  clearMockResponses(): void
-}
-
-export class MockAiService implements AiServiceLegacy {
-  private mockResponses: Map<string, any> = new Map()
-
-  setMockResponse(input: string, response: any): void {
-    this.mockResponses.set(input, response)
-  }
-
-  async generate(
-    input: string,
-    systemPrompt: string,
-    history?: any[],
-  ): Promise<any> {
-    if (this.mockResponses.has(input)) {
-      return this.mockResponses.get(input)
-    }
-
-    return {
-      response: {
-        text: () => `Mock AI response for: ${input.substring(0, 50)}...`,
-      },
-    }
-  }
-
-  clearMockResponses(): void {
-    this.mockResponses.clear()
-  }
-}
-
 export class MockAiProvider implements AiProvider {
   private mockResponses: Map<string, string> = new Map()
 


### PR DESCRIPTION
This PR removes the legacy AiService shim and its mock, consolidating on the AiProvider port.

Changes:
- Delete AiServiceAdapter and all references.
- Remove MockAiService from test/dev wiring.
- Keep VertexAiProviderAdapter and MockAiProvider as the only AI port implementations.
- Update DI factories to expose only aiProvider.

Validation:
- Ran full test suite locally: all green.
- Verified no remaining references to AiService in src/.

Closes #58.