### PR TITLE
chore: add root pyproject.toml dev tooling and workspace README (closes #67)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,78 @@
 
 An ESM TypeScript Telegram bot built with Telegraf, deployed to AWS Lambda via Serverless, and organized as a modular monolith with dependency injection.
 
+## Python monorepo scaffold (Poetry + Monoranger)
+
+This repo now also hosts a minimal Python monorepo scaffold to support multiple MCP services alongside the Telegram bot app. It's intentionally simple and defers non-essential tooling to future issues.
+
+Structure:
+
+```
+apps/
+	telegram-bot/
+		pyproject.toml
+		src/telegram_bot/__init__.py
+services/
+	gaming-social-mcp/
+		pyproject.toml
+		src/gaming_social_mcp/__init__.py
+	content-deals-mcp/
+		pyproject.toml
+		src/content_deals_mcp/__init__.py
+libs/
+	common/
+		pyproject.toml
+		src/common/__init__.py
+	mcp_utils/
+		pyproject.toml
+		src/mcp_utils/__init__.py
+
+pyproject.toml   # root: Poetry in non-package mode + Monoranger workspace packages
+
+### Python workspace (how to use)
+
+The repository contains a lightweight Python monorepo scaffold managed with Poetry (root in non-package mode) and Monoranger for workspace discovery.
+
+Install dependencies and run tooling from the repository root:
+
+```bash
+# Install Poetry (official installer recommended)
+curl -sSL https://install.python-poetry.org | python3 -
+
+# Make sure Poetry's bin directory is on your PATH (example for Bash/zsh)
+export PATH="$HOME/.local/bin:$PATH"
+
+# From the repo root: create the venv and install workspace dev deps
+poetry install
+
+# Run formatters and tests from the root (uses the workspace virtualenv)
+poetry run black --check .
+poetry run isort --check-only .
+poetry run pytest -q || true   # exits non-zero if there are no tests yet
+```
+
+Notes:
+- The root `pyproject.toml` contains a small dev group with `black`, `isort`, and `pytest` and a `[tool.monoranger]` package list used by Monoranger.
+- Subpackages keep their own `pyproject.toml` for package metadata; dev tooling is centralized at the root to avoid duplication.
+
+```
+
+Root `pyproject.toml` config:
+
+- Poetry package-mode disabled (dependency/env mgmt only)
+- Monoranger workspace package list under `[tool.monoranger]`
+
+Minimal bootstrap (per package):
+
+1) Install Poetry if needed (https://python-poetry.org/docs/#installation)
+2) In each package directory (e.g. `apps/telegram-bot`):
+
+```bash
+poetry install
+poetry run python -c "import sys; print(sys.version)"
+```
+
+Note: Monoranger is configured at the root via `[tool.monoranger]` and can be wired later for workspace-aware operations.
 ## Prerequisites
 - Node version from `.nvmrc` (use `nvm install && nvm use`)
 - Environment variables (see `.env.example`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,90 @@
+[project]
+name = "burguesesbot-monorepo"
+version = "0.0.0"
+description = "Monorepo scaffold for MCP services and Telegram bot"
+readme = "README.md"
+requires-python = ">=3.10"
+
+[build-system]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+# Using Poetry only for env/deps at the root. Individual packages can define their own pyproject later.
+package-mode = false
+
+# Monoranger workspace configuration (scaffold). This will be used by Monoranger to discover packages.
+[tool.monoranger]
+packages = [
+  "apps/telegram-bot",
+  "services/gaming-social-mcp",
+  "services/content-deals-mcp",
+  "libs/common",
+  "libs/mcp_utils",
+]
+
+# Minimal shared dev dependencies and tooling config for the monorepo
+[tool.poetry.group.dev]
+optional = false
+
+[tool.poetry.group.dev.dependencies]
+black = "^24.1"
+isort = "^5.12"
+pytest = "^8.4"
+
+[tool.black]
+line-length = 88
+target-version = ["py310"]
+
+[tool.isort]
+profile = "black"
+
+[tool.pytest.ini_options]
+minversion = "7.0"
+addopts = "-q"
+testpaths = ["tests"]
+[project]
+name = "burguesesbot-monorepo"
+version = "0.0.0"
+description = "Monorepo scaffold for MCP services and Telegram bot"
+readme = "README.md"
+requires-python = ">=3.10"
+
+[build-system]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+# Using Poetry only for env/deps at the root. Individual packages can define their own pyproject later.
+package-mode = false
+
+# Monoranger workspace configuration (scaffold). This will be used by Monoranger to discover packages.
+[tool.monoranger]
+packages = [
+  "apps/telegram-bot",
+  "services/gaming-social-mcp",
+  "services/content-deals-mcp",
+  "libs/common",
+  "libs/mcp_utils",
+]
+
+# Minimal shared dev dependencies and tooling config for the monorepo
+[tool.poetry.group.dev]
+optional = false
+
+[tool.poetry.group.dev.dependencies]
+black = "^24.1"
+isort = "^5.12"
+pytest = "^8.4"
+
+[tool.black]
+line-length = 88
+target-version = ["py310"]
+
+[tool.isort]
+profile = "black"
+
+[tool.pytest.ini_options]
+minversion = "7.0"
+addopts = "-q"
+testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,48 +43,4 @@ profile = "black"
 minversion = "7.0"
 addopts = "-q"
 testpaths = ["tests"]
-[project]
-name = "burguesesbot-monorepo"
-version = "0.0.0"
-description = "Monorepo scaffold for MCP services and Telegram bot"
-readme = "README.md"
-requires-python = ">=3.10"
 
-[build-system]
-requires = ["poetry-core>=2.0.0,<3.0.0"]
-build-backend = "poetry.core.masonry.api"
-
-[tool.poetry]
-# Using Poetry only for env/deps at the root. Individual packages can define their own pyproject later.
-package-mode = false
-
-# Monoranger workspace configuration (scaffold). This will be used by Monoranger to discover packages.
-[tool.monoranger]
-packages = [
-  "apps/telegram-bot",
-  "services/gaming-social-mcp",
-  "services/content-deals-mcp",
-  "libs/common",
-  "libs/mcp_utils",
-]
-
-# Minimal shared dev dependencies and tooling config for the monorepo
-[tool.poetry.group.dev]
-optional = false
-
-[tool.poetry.group.dev.dependencies]
-black = "^24.1"
-isort = "^5.12"
-pytest = "^8.4"
-
-[tool.black]
-line-length = 88
-target-version = ["py310"]
-
-[tool.isort]
-profile = "black"
-
-[tool.pytest.ini_options]
-minversion = "7.0"
-addopts = "-q"
-testpaths = ["tests"]


### PR DESCRIPTION
This PR implements a minimal root-level Poetry workspace configuration and adds centralized dev tooling for the Python monorepo.

What I changed
- Updated root `pyproject.toml`:
  - `package-mode = false` (root used for dependency/env management)
  - Added `[tool.monoranger]` package list (workspace discovery scaffold)
  - Added `[tool.poetry.group.dev.dependencies]` with `black`, `isort`, and `pytest`
  - Added minimal `[tool.black]`, `[tool.isort]`, and `[tool.pytest.ini_options]` configs
- Updated `README.md` with a "Python workspace" usage section showing how to install Poetry, run `poetry install`, and invoke formatting/tests from the root.

Why
- Centralizes dev tooling for the monorepo and makes it simple to bootstrap development across `apps/*`, `libs/*`, and `services/*`.

How I validated
- Installed Poetry 2.2.1 in the environment and ran `poetry install` at the repo root.
- Verified `black` and `isort` are available via `poetry run`.
- Verified `pytest` runs (note: it returns exit code 5 when no tests are present; the README demonstrates a tolerant invocation).

Acceptance criteria mapping (issue #67)
- Root `pyproject.toml` exists with Poetry configuration and `package-mode = false` — Done
- Monoranger workspace includes `apps/*`, `services/*`, and `libs/*` — Done (explicit package list)
- Minimal dev dependencies declared (black, isort, pytest) — Done
- Sub-packages continue to use individual `pyproject.toml` for package metadata — Kept as-is
- `poetry install` at root resolves workspace deps without errors — Verified locally

Closes #67
